### PR TITLE
Add tick marks every hour on x-axis

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -16,6 +16,15 @@
       rect.selected { fill: red; }
 
       #selection-info { display: flex; }
+
+      .xaxis .tick {
+        stroke: #555;
+      }
+
+      .xaxis text {
+        stroke: #555;
+        font-size: 12px;
+      }
     </style>
   </head>
   <body>

--- a/main.js
+++ b/main.js
@@ -110,9 +110,11 @@ var createChart = function createChart (element, data, opts) {
   brush.x(timeScale).on('brush', brushed);
   brush.x(timeScale).on('brushend', brushEnded);
 
+  var xAxisOffset = chartHeight + 10;
   var xAxis = d3.svg.axis()
-                    .ticks(d3.time.hours, 2)
-                    .scale(timeScale);
+                    .ticks(d3.time.hours, 1)
+                    .scale(timeScale)
+                    .tickSize(xAxisOffset * -1, 0, 0);
 
   var yAxis = d3.svg.axis()
                     .tickPadding([10])
@@ -127,7 +129,7 @@ var createChart = function createChart (element, data, opts) {
 
   chartData.append('g')
            .attr('class', 'xaxis')
-           .attr('transform', 'translate(0,' + (chartHeight + 10) + ')')
+           .attr('transform', 'translate(0,' + xAxisOffset + ')')
            .call(xAxis);
 
   chartData.append('g')


### PR DESCRIPTION
<img width="1252" alt="screen shot 2016-07-26 at 2 12 48 pm" src="https://cloud.githubusercontent.com/assets/150988/17153700/1480ca84-533b-11e6-931d-10f30c89f9f3.png">

The tick marks/labels can be styled through CSS

The format/frequency of the ticks along the x-axis should probably customizable, but we can fix that in a later commit.

cc @nicholaspufal 
