### PR TITLE
Support rendering tooltips on each chart element

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -1,5 +1,6 @@
 <html>
   <head>
+    <link rel="stylesheet" href="//rawgithub.com/Caged/d3-tip/master/examples/example-styles.css">
     <style type="text/css">
       * {
         margin: 0px auto;

--- a/example/sample.json
+++ b/example/sample.json
@@ -50,11 +50,13 @@
     {
       "label": "running",
       "startedAt": 1467783800,
-      "endedAt": 1467786800
+      "endedAt": 1467786800,
+      "tooltip": "running 🏃"
     },
     {
       "label": "coffee",
-      "at": 1467783800
+      "at": 1467783800,
+      "tooltip": "custom tooltip"
     },
     {
       "label": "coffee",

--- a/lib/tooltip.js
+++ b/lib/tooltip.js
@@ -1,0 +1,26 @@
+function toDate (timeInSeconds) {
+  return new Date(timeInSeconds * 1000);
+}
+
+function defaultTooltip (d) {
+  if (d.hasOwnProperty('at')) {
+    return 'at: ' + toDate(d.at);
+  } else {
+    return 'from ' + toDate(d.startedAt) + ' to ' + toDate(d.endedAt);
+  }
+}
+
+function tipHtml (d) {
+  return d.tooltip || defaultTooltip(d);
+}
+
+function create (d) {
+  return d3.tip()
+  .attr('class', 'd3-tip')
+  .offset([-10, 0])
+  .html(tipHtml);
+}
+
+module.exports = {
+  create: create
+};


### PR DESCRIPTION
This is just an alternative approach to https://github.com/PetroFeed/d3-selectable-gantt-chart/pull/8 so that we could keep the brushing behaviour and supporting the tooltips at the same time.

Inspiration: http://wrobstory.github.io/2013/11/D3-brush-and-tooltip.html
