### PR TITLE
Introduce `ids` to the source data

### DIFF
--- a/example/example.js
+++ b/example/example.js
@@ -18,6 +18,7 @@ function updateSelectionInfo (timeRange) {
 }
 
 function appendItemInformation (item) {
+  activitiesInfo.append('dt').text('ID: ' + item.id);
   activitiesInfo.append('dt').text('Label: ' + item.label);
   if (item.hasOwnProperty('startedAt')) {
     activitiesInfo.append('dd').text('Bar start: ' + new Date(item.startedAt * 1000));
@@ -39,6 +40,12 @@ function updateBarInfo (item) {
   appendItemInformation(item);
 }
 
+var ID = 999;
+function createBar (barAttrs) {
+  barAttrs.id = ID++;
+  return barAttrs;
+}
+
 d3.json('http://localhost:8080/sample.json', function (data) {
   var chartElement = document.getElementById('chart');
   var opts = {
@@ -52,7 +59,7 @@ d3.json('http://localhost:8080/sample.json', function (data) {
     },
     onBarClicked: updateBarInfo,
     onBarChanged: updateBarInfo,
-    onBarCreated: function () { console.log('bar created', arguments); }
+    onBarCreated: createBar
   };
 
   chart = new TimelineChart(chartElement, data, opts);

--- a/example/sample.json
+++ b/example/sample.json
@@ -8,57 +8,68 @@
   ],
   "events": [
     {
+      "id": 1,
       "label": "sitting",
       "startedAt": 1467817234,
       "endedAt": 1467818332
     },
     {
+      "id": 2,
       "label": "sitting",
       "startedAt": 1467829218,
       "endedAt": 1467829643
     },
     {
+      "id": 3,
       "label": "driving",
       "startedAt": 1467836050,
       "endedAt": 1467846224
     },
     {
+      "id": 4,
       "label": "driving",
       "startedAt": 1467784801,
       "endedAt": 1467835500
     },
     {
+      "id": 5,
       "label": "sitting",
       "startedAt": 1467829774,
       "endedAt": 1467830194
     },
     {
+      "id": 6,
       "label": "sitting",
       "startedAt": 1467830323,
       "endedAt": 1467830469
     },
     {
+      "id": 7,
       "label": "sitting",
       "startedAt": 1467830962,
       "endedAt": 1467833150
     },
     {
+      "id": 8,
       "label": "sitting",
       "startedAt": 1467836754,
       "endedAt": 1467842349
     },
     {
+      "id": 9,
       "label": "running",
       "startedAt": 1467783800,
       "endedAt": 1467786800,
       "tooltip": "running 🏃"
     },
     {
+      "id": 10,
       "label": "coffee",
       "at": 1467783800,
       "tooltip": "custom tooltip"
     },
     {
+      "id": 11,
       "label": "coffee",
       "at": 1467830094
     }

--- a/lib/bar.js
+++ b/lib/bar.js
@@ -1,4 +1,5 @@
 function Bar (props) {
+  this.id = props.id;
   this.label = props.label;
   this.startedAt = props.startedAt;
   this.endedAt = props.endedAt;
@@ -7,6 +8,7 @@ function Bar (props) {
 
 Bar.prototype.expandLeft = function expandLeft (startedAt) {
   return new Bar({
+    id: this.id,
     label: this.label,
     selected: this.selected,
     startedAt: startedAt,
@@ -16,6 +18,7 @@ Bar.prototype.expandLeft = function expandLeft (startedAt) {
 
 Bar.prototype.expandRight = function expandRight (endedAt) {
   return new Bar({
+    id: this.id,
     label: this.label,
     selected: this.selected,
     startedAt: this.startedAt,
@@ -27,6 +30,7 @@ Bar.prototype.move = function move (startedAt) {
   var duration = this.endedAt - this.startedAt;
 
   return new Bar({
+    id: this.id,
     label: this.label,
     selected: this.selected,
     startedAt: startedAt,

--- a/main.js
+++ b/main.js
@@ -1,3 +1,4 @@
+var Bar = require('./lib/bar');
 var DateCalculator = require('./lib/date.calculator');
 var DataHelper = require('./lib/data.helper');
 var Drag = require('./lib/drag');
@@ -132,21 +133,17 @@ function TimelineChart (element, data, opts) {
   function brushEnded () {
     if (brush.empty()) {
       var selection = d3.selectAll('.selected');
-      if (!selection.empty()) {
-        var selectedData = selection.data()[0];
-        opts.onBarClicked(selectedData);
-        Drag.enable(chartData, opts, scales, selectedData, events);
-        removeBrush();
-      } else {
+      if (selection.empty()) {
         var label = getBrushedLabel();
         if (!DataHelper.isEditable(label, data)) { return false; }
-        var newBar = {
+
+        var barAttrs = {
           startedAt: brush.extent()[0].getTime() / 1000,
           endedAt: brush.extent()[1].getTime() / 1000 + 600,
           label: label
         };
+        var newBar = opts.onBarCreated(barAttrs);
         events.push(newBar);
-        opts.onBarCreated(newBar);
         renderEvents(chartDataGroup, events);
         rectClicked(newBar);
       }
@@ -171,7 +168,7 @@ function TimelineChart (element, data, opts) {
     Drag.disable();
     Drag.enable(chartData, opts, scales, d, events);
     removeBrush();
-    opts.onBarClicked(d);
+    opts.onBarClicked(new Bar(d));
   }
 
   function addBrush () {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A selectable gantt chart in d3",
   "main": "main.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "make test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The rationale for this is that since this component now offers the
ability to edit/create new elements, it makes sense to uniquely
identify each of the elements in the chart. Otherwise it becomes really
hard for the client to figure out which elements were changed in the
chart based on the output of the callbacks only.
