### PR TITLE
Scrollable timeline

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -8,7 +8,8 @@
         font-family: sans-serif;
       }
 
-      #chart { width: 100%; }
+      #chart_wrapper { overflow: scroll; }
+      #chart { width: 2000px; }
 
       ul { list-style: none; }
 
@@ -29,9 +30,12 @@
       }
     </style>
   </head>
+
   <body>
     <h2>Chart</h2>
-    <div id="chart"></div>
+    <div id="chart_wrapper">
+      <div id="chart"></div>
+    </div>
     <div id="selection-info"></div>
 
     <a href="#" id="clearBrush">Clear brush</a>

--- a/example/index.html
+++ b/example/index.html
@@ -8,8 +8,7 @@
         font-family: sans-serif;
       }
 
-      #chart_wrapper { overflow: scroll; }
-      #chart { width: 2000px; }
+      #chart_wrapper { overflow: scroll; overflow-y: hidden; }
 
       ul { list-style: none; }
 

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ function TimelineChart (element, data, opts) {
     opts.barRoundSize = opts.barRoundSize || 10;
     opts.xAxisHeight  = opts.xAxisHeight || 60;
     opts.margin       = { top: 200, right: 40, bottom: 200, left: 40 };
-    opts.width        = element.clientWidth - opts.margin.left - opts.margin.right;
+    opts.width        = (element.clientWidth - opts.margin.left - opts.margin.right) * 3.2;
     opts.onBarClicked = opts.onBarClicked || noop;
     opts.onBarChanged = opts.onBarChanged || noop;
     opts.onBarCreated = opts.onBarCreated || noop;


### PR DESCRIPTION
This PR allows the timeline to be scrollable, having the width of the scrollable content default to 3.2 times the size of the current window. This pretty much always makes it so that the times displayed on init are 12:00AM - 7:00AM like in the mockups. I went back and forth a lot last night on how the width should be defined, if it should be set or relative to the size of the window, but since the requirements were that it show 6 hours at a time I figured this was the best way to go. Lots of options available if we decide a set size is best. 

It was asked if the content would scroll when you drag activity handlebars, and the good news is it does! 

Here is a screen: 
<img width="913" alt="screen shot 2016-09-13 at 8 16 16 am" src="https://cloud.githubusercontent.com/assets/955108/18479652/a085f99e-798a-11e6-9422-1123588f6366.png">

Am working now on getting the overlay bar with the time at the center updating properly. Isn't trivial at all. 
